### PR TITLE
Allow customizable highlights

### DIFF
--- a/src/main/kotlin/com/giathuan/kotlinter/ktproto/KtProtoCreationInspection.kt
+++ b/src/main/kotlin/com/giathuan/kotlinter/ktproto/KtProtoCreationInspection.kt
@@ -9,7 +9,6 @@ import com.giathuan.kotlinter.ktproto.support.model.KtProtoCreatorExpression.Com
 import com.giathuan.kotlinter.ktproto.support.parser.JavaProtoExpressionResolver.parseJavaProtoBuildExpression
 import com.giathuan.kotlinter.ktproto.support.parser.SetterResolver.buildSettersCode
 import com.giathuan.kotlinter.ktproto.support.utility.StringTransformer.unwrapRoundBracket
-import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel
 import com.intellij.psi.PsiElementVisitor
@@ -46,7 +45,6 @@ class KtProtoCreationInspection(@JvmField var avoidThisExpression: Boolean = fal
     holder.registerProblem(
         element.originalElement,
         "Kotlinter: Better DSL for proto builder is available in Kotlin",
-        ProblemHighlightType.WARNING,
         ExpressionReplacerQuickFix(dsl, name = "Kotlinter: Transform to Kotlin DSL"))
   }
 

--- a/src/main/kotlin/com/giathuan/kotlinter/ktproto/KtProtoGetDefaultInstanceInspection.kt
+++ b/src/main/kotlin/com/giathuan/kotlinter/ktproto/KtProtoGetDefaultInstanceInspection.kt
@@ -2,7 +2,6 @@ package com.giathuan.kotlinter.ktproto
 
 import com.giathuan.kotlinter.ktproto.support.fix.ExpressionReplacerQuickFix
 import com.giathuan.kotlinter.ktproto.support.parser.JavaProtoExpressionResolver.parseJavaGetDefaultInstanceExpression
-import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import org.jetbrains.kotlin.idea.inspections.AbstractKotlinInspection
@@ -26,7 +25,6 @@ class KtProtoGetDefaultInstanceInspection : AbstractKotlinInspection() {
     holder.registerProblem(
         element.originalElement,
         "Kotlinter: Better DSL for .getDefaultInstance() is available in Kotlin",
-        ProblemHighlightType.WARNING,
         ExpressionReplacerQuickFix(dsl, "Kotlinter: Transform .getDefaultInstance() to Kotlin DS"))
   }
 }

--- a/src/main/kotlin/com/giathuan/kotlinter/ktproto/KtProtoSetterUsingBuilderArgumentInspection.kt
+++ b/src/main/kotlin/com/giathuan/kotlinter/ktproto/KtProtoSetterUsingBuilderArgumentInspection.kt
@@ -4,7 +4,6 @@ import com.giathuan.kotlinter.ktproto.support.parser.JavaProtoExpressionResolver
 import com.giathuan.kotlinter.ktproto.support.parser.JavaProtoExpressionResolver.isJavaProtoMissingBuildExpression
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel
 import com.intellij.openapi.project.Project
@@ -44,7 +43,6 @@ class KtProtoSetterUsingBuilderArgumentInspection(
       holder.registerProblem(
           lastSetter.originalElement,
           "Kotlinter: You should add a .build()",
-          ProblemHighlightType.WARNING,
           AddBuildQuickFix())
     }
   }


### PR DESCRIPTION
Turns out that `ProblemHighlightType` supports this by default, and even says:
> Please use {@link #GENERIC_ERROR_OR_WARNING}, otherwise user's settings would be ignored.

As a matter of fact `registerProblem` has an overload that *doesn't* take a
`ProblemHighlightType`, and defaults to `GENERIC_ERROR_OR_WARNING`. This is
actually what `CustomizableKDocMissingDocumentationInspection` does.

With this change, users can go into the options, and can chose to lower the
severity of the issue to (for example) "weak warning" or "consideration", if
they so wish.

![image](https://github.com/duckladydinh/kotlinter/assets/43784631/6fba2e42-1bae-4477-ad58-17fc154c3f3b)

